### PR TITLE
Module 7.6 - task Zadanie: średnia ilość dni realizacji zadania

### DIFF
--- a/kodilla-stream/src/main/java/com/kodilla/stream/portfolio/TaskList.java
+++ b/kodilla-stream/src/main/java/com/kodilla/stream/portfolio/TaskList.java
@@ -34,6 +34,7 @@ public final class TaskList {
 
         TaskList taskList = (TaskList) o;
 
+        //if (!tasks.equals(taskList.tasks)) return false; //to jest linia, która powoduje, że testy nie przechodzą
         return name.equals(taskList.name);
     }
 }

--- a/kodilla-stream/src/test/java/com/kodilla/stream/portfolio/BoardTestSuite.java
+++ b/kodilla-stream/src/test/java/com/kodilla/stream/portfolio/BoardTestSuite.java
@@ -151,7 +151,7 @@ public class BoardTestSuite {
         //Given
         Board project = prepareTestData();
 
-        //When
+        //When1 - two streams: sumOfDays and numberOfTasks
         List<TaskList> inProgressTasks = new ArrayList<>();
         inProgressTasks.add(new TaskList("In progress"));
         int sumOfDays = project.getTaskLists().stream()
@@ -159,16 +159,27 @@ public class BoardTestSuite {
                 .flatMap(tl -> tl.getTasks().stream())
                 .map(t -> Period.between(t.getCreated(), LocalDate.now()).getDays())
                 .reduce(0, (sum, current) -> sum += current);
-        int numberOfTasks = project.getTaskLists().stream()
+        long numberOfTasks = project.getTaskLists().stream()
                 .filter(inProgressTasks::contains)
                 .flatMap(tl -> tl.getTasks().stream())
-                .map(task -> Period.between(task.getCreated(), LocalDate.now()).getDays())
                 .map(t -> 1)
-                .reduce(0, (sum, current) -> sum += current);
+                .count();
 
-        double averageDuration = sumOfDays / numberOfTasks;
+        double averageDuration = (double)sumOfDays / numberOfTasks;
 
-        //Then
+        //Then1
         Assert.assertEquals(10, averageDuration, 0.001);
+
+        //When2 - stream().average()
+        double avg = project.getTaskLists().stream()
+                .filter(inProgressTasks::contains)
+                .flatMap(tl -> tl.getTasks().stream())
+                .map(t -> Period.between(t.getCreated(), LocalDate.now()).getDays())
+                .mapToDouble(a -> a)
+                .average()
+                .getAsDouble();
+
+        //Then2
+        Assert.assertEquals(10,avg, 0.001);
     }
 }

--- a/kodilla-stream/src/test/java/com/kodilla/stream/portfolio/BoardTestSuite.java
+++ b/kodilla-stream/src/test/java/com/kodilla/stream/portfolio/BoardTestSuite.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -142,5 +143,32 @@ public class BoardTestSuite {
 
         //Then
         Assert.assertEquals(2, longTasks);
+    }
+
+    //Zadanie 7.6 - średnia ilość dni realizacji zadania
+    @Test
+    public void testAddTaskListAverageWorkingOnTask() {
+        //Given
+        Board project = prepareTestData();
+
+        //When
+        List<TaskList> inProgressTasks = new ArrayList<>();
+        inProgressTasks.add(new TaskList("In progress"));
+        int sumOfDays = project.getTaskLists().stream()
+                .filter(inProgressTasks::contains)
+                .flatMap(tl -> tl.getTasks().stream())
+                .map(t -> Period.between(t.getCreated(), LocalDate.now()).getDays())
+                .reduce(0, (sum, current) -> sum += current);
+        int numberOfTasks = project.getTaskLists().stream()
+                .filter(inProgressTasks::contains)
+                .flatMap(tl -> tl.getTasks().stream())
+                .map(task -> Period.between(task.getCreated(), LocalDate.now()).getDays())
+                .map(t -> 1)
+                .reduce(0, (sum, current) -> sum += current);
+
+        double averageDuration = sumOfDays / numberOfTasks;
+
+        //Then
+        Assert.assertEquals(10, averageDuration, 0.001);
     }
 }


### PR DESCRIPTION
                  Celem zadania jest obliczenie średniej ilości dni, jaka upłynęła od zlecenia wykonania zadania do dnia bieżącego w liście zadań, które są aktualnie w trakcie realizacji. Do jego wykonania można użyć dwóch strumieni - jeden aby obliczyć sumę, a drugi aby obliczyć ilość elementów. Lub wersja trudna (z gwiazdką :) ) - należy wykorzystać kolektor skalarny average().

                  Aby zrealizować zadanie:

                  Stwórz nowy przypadek testowy testAddTaskListAverageWorkingOnTask()
                  Utwórz wymagane zmienne pomocnicze, a następnie uruchom strumień na kolekcji getTaskLists klasy Board
                  Napisz sekwencję funkcji obliczającą średni czas wykonywania zadania z listy “In Progress”
                  Napisz asercje sprawdzające otrzymany wynik